### PR TITLE
Fix search button style

### DIFF
--- a/templates/grad_drupal_common_footer.html.twig
+++ b/templates/grad_drupal_common_footer.html.twig
@@ -36,7 +36,7 @@
     <div class="card card-borderless bg-transparent h-100">
       <div class="card-body d-flex flex-column">
         <div class="card-text">
-          <form class="search-form search-block-form" accept-charset="UTF-8" method="GET" action="https://grad.arizona.edu/tools/search">
+          <form class="search-form" accept-charset="UTF-8" method="GET" action="https://grad.arizona.edu/tools/search">
             <div class="input-group">
               <label for="grad-common-search" class="sr-only">Search</label>
               <input id="grad-common-search" name="q" class="form-control" type="text" title="Search all GRAD websites" aria-label="Search all GRAD websites" aria-describedby="search-button" placeholder="Search all GRAD websites" onfocus="this.placeholder=''" onblur="this.placeholder='Search all GRAD websites'">


### PR DESCRIPTION
Removes a CSS class that was causeing the search form button to be displayed
red-on-white instead of white-on-red due to an upstream change in Quickstart.

Fixes #3